### PR TITLE
Mobile Web View - fix for mobile hotels search with google maps - LM-122

### DIFF
--- a/src/components/hotels/search/google-map/MultiMarkerGoogleMap.jsx
+++ b/src/components/hotels/search/google-map/MultiMarkerGoogleMap.jsx
@@ -110,7 +110,7 @@ class MultiMarkerGoogleMap extends Component {
     const locPrice = ((hotel.price / locEurRate) / nights).toFixed(2);
     const fiatPrice = currencyExchangeRates && ((CurrencyConverter.convert(currencyExchangeRates, RoomsXMLCurrency.get(), currency, hotel.price)) / nights).toFixed(2);
     const isMobile = location.pathname.indexOf('/mobile') !== -1;
-    const rootUrl = isMobile ? '/mobile/details' : '/hotels/listings';
+    const rootUrl = isMobile ? '/mobile/hotels/listings' : '/hotels/listings';
 
     const content = ReactDOMServer.renderToString(
       <MarkerInfoWindow


### PR DESCRIPTION
Clicking **a marker on the map** opens a hotel Info Window. Clicking the Info Window **resolves to a dead router "/mobile/details"** instead of **"/mobile/hotels/listings"**